### PR TITLE
ドラッグアンドドロップで画像をポストする機能の追加

### DIFF
--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -4,31 +4,42 @@ import styled from "styled-components";
 import Image from "../image/image.svg";
 
 type UploadFile = (e: ChangeEvent<HTMLInputElement>) => Promise<void>;
+type PostImageData = (files: FileList | null) => Promise<void>;
 
 const URL = "http://localhost:4000/public/image";
+
+const postImageData: PostImageData = async (files) => {
+  const postImage = new FormData();
+
+  if (!files) {
+    return;
+  }
+
+  postImage.append("image", files[0]);
+
+  try {
+    await axios.post(URL, postImage, {
+      headers: {
+        "Content-Type": "multipart/form-data",
+      },
+    });
+  } catch (e) {
+    console.error(e);
+  }
+};
 
 const ImageUploader: VFC = () => {
   const uploadFile: UploadFile = async (e) => {
     const { files } = e.target;
-    const postImage = new FormData();
 
     if (!files) {
       alert("Please select your image");
       return;
     }
 
-    postImage.append("image", files[0]);
-    e.target.value = "";
+    await postImageData(files);
 
-    try {
-      await axios.post(URL, postImage, {
-        headers: {
-          "Content-Type": "multipart/form-data",
-        },
-      });
-    } catch (e) {
-      console.error(e);
-    }
+    e.target.value = "";
   };
 
   return (

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -3,7 +3,7 @@ import type { VFC, ChangeEvent } from "react";
 import styled from "styled-components";
 import Image from "../image/image.svg";
 
-type UploadFile = (e: ChangeEvent<HTMLInputElement>) => Promise<void>;
+type OnChangeInput = (e: ChangeEvent<HTMLInputElement>) => Promise<void>;
 type PostImageData = (files: FileList | null) => Promise<void>;
 
 const URL = "http://localhost:4000/public/image";
@@ -29,7 +29,7 @@ const postImageData: PostImageData = async (files) => {
 };
 
 const ImageUploader: VFC = () => {
-  const uploadFile: UploadFile = async (e) => {
+  const onChangeInput: OnChangeInput = async (e) => {
     const { files } = e.target;
 
     if (!files) {
@@ -56,7 +56,7 @@ const ImageUploader: VFC = () => {
           name="image"
           accept="image/*"
           type="file"
-          onChange={uploadFile}
+          onChange={onChangeInput}
         />
       </InputLabel>
     </ImageUploaderConteiner>

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -1,10 +1,11 @@
 import axios from "axios";
-import type { VFC, ChangeEvent } from "react";
+import type { VFC, ChangeEvent, DragEvent, MouseEvent } from "react";
 import styled from "styled-components";
 import Image from "../image/image.svg";
 
 type OnChangeInput = (e: ChangeEvent<HTMLInputElement>) => Promise<void>;
 type PostImageData = (files: FileList | null) => Promise<void>;
+type OnDrop = (e: DragEvent) => Promise<void>;
 
 const URL = "http://localhost:4000/public/image";
 
@@ -42,11 +43,31 @@ const ImageUploader: VFC = () => {
     e.target.value = "";
   };
 
+  const onDrop: OnDrop = async (e) => {
+    e.preventDefault();
+
+    const { files } = e.dataTransfer;
+
+    if (files.length > 1) {
+      alert("Please select only one image");
+      return;
+    } else if (!files[0].type.includes("image/")) {
+      alert("Please select a image file (jpeg, png...)");
+      return;
+    }
+
+    await postImageData(e.dataTransfer.files);
+  };
+
+  const onDragOver = (e: MouseEvent) => {
+    e.preventDefault();
+  };
+
   return (
     <ImageUploaderConteiner>
       <Header>Upload your image</Header>
       <Hint>FIle should be Jpeg Png...</Hint>
-      <DragAndDrop>
+      <DragAndDrop onDrop={onDrop} onDragOver={onDragOver}>
         <div>Drag & Drop your image here</div>
       </DragAndDrop>
       <Or>Or</Or>


### PR DESCRIPTION
## 目的
devChallenge - Image Uploader 
([https://devchallenges.io/challenges/O2iGT9yBd6xZBrOcVirx](https://devchallenges.io/challenges/O2iGT9yBd6xZBrOcVirx))のユーザーストーリより
- User story: I can drag and drop an image to upload it

の実装のため

## 内容
- 点線の枠内に画像をドロップすると`FormData`にセットして、サーバにポストする機能を追加

## 確認手順
![draganddrop](https://user-images.githubusercontent.com/66302618/141626745-9c150791-bc47-4e42-8e50-8d4f60c53772.PNG)
の点線内に画像をドロップする

## 変更結果
ドラッグアンドドロップでも画像がアップロードできるようになった