### PR TITLE
アップロードした画像をプレビューする機能を追加

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -30,6 +30,10 @@
       href="https://fonts.googleapis.com/css2?family=Noto+Sans&family=Poppins:wght@500&display=swap"
       rel="stylesheet"
     />
+    <link
+      href="https://fonts.googleapis.com/icon?family=Material+Icons"
+      rel="stylesheet"
+    />
 
     <title>Image Uploader</title>
   </head>

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -92,13 +92,13 @@ const ImageUploader: VFC = () => {
         {imageData ? "Uploaded Successfully!" : "Upload your image"}
       </Header>
       {imageData ? null : <Hint>FIle should be Jpeg Png...</Hint>}
-      <DragAndDrop onDrop={onDrop} onDragOver={onDragOver}>
-        {imageData ? (
-          <img src={imageData as string} alt="here" />
-        ) : (
+      {imageData ? (
+        <img src={imageData as string} alt="here" />
+      ) : (
+        <DragAndDrop onDrop={onDrop} onDragOver={onDragOver}>
           <div>Drag & Drop your image here</div>
-        )}
-      </DragAndDrop>
+        </DragAndDrop>
+      )}
       {imageData ? null : <Or>Or</Or>}
       {imageData ? (
         <CopyLink>

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -85,7 +85,9 @@ const ImageUploader: VFC = () => {
 
   return (
     <ImageUploaderConteiner>
-      {imageData ? <span className="material-icons">check_circle</span> : null}
+      {imageData ? (
+        <MaterialIcon className="material-icons">check_circle</MaterialIcon>
+      ) : null}
       <Header>
         {imageData ? "Uploaded Successfully!" : "Upload your image"}
       </Header>
@@ -181,4 +183,8 @@ const InputLabel = styled.label`
   }
 `;
 
+const MaterialIcon = styled.span`
+  font-size: 40px;
+  color: #219653;
+`;
 export default ImageUploader;

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { useState } from "react";
 import type { VFC, ChangeEvent, DragEvent, MouseEvent } from "react";
 import styled from "styled-components";
 import Image from "../image/image.svg";
@@ -30,6 +31,15 @@ const postImageData: PostImageData = async (files) => {
 };
 
 const ImageUploader: VFC = () => {
+  const [imageData, setImageData] = useState<string | ArrayBuffer | null>();
+  const reader = new FileReader();
+  reader.onload = (e) => {
+    if (!e.target) {
+      return;
+    }
+    setImageData(e.target.result);
+  };
+
   const onChangeInput: OnChangeInput = async (e) => {
     const { files } = e.target;
 
@@ -40,6 +50,7 @@ const ImageUploader: VFC = () => {
 
     try {
       await postImageData(files);
+      reader.readAsDataURL(files[0]);
     } catch (e) {
       alert("Upload failed");
     }
@@ -62,6 +73,7 @@ const ImageUploader: VFC = () => {
 
     try {
       await postImageData(e.dataTransfer.files);
+      reader.readAsDataURL(files[0]);
     } catch (e) {
       alert("Upload failed");
     }

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -85,21 +85,35 @@ const ImageUploader: VFC = () => {
 
   return (
     <ImageUploaderConteiner>
-      <Header>Upload your image</Header>
-      <Hint>FIle should be Jpeg Png...</Hint>
+      {imageData ? <span className="material-icons">check_circle</span> : null}
+      <Header>
+        {imageData ? "Uploaded Successfully!" : "Upload your image"}
+      </Header>
+      {imageData ? null : <Hint>FIle should be Jpeg Png...</Hint>}
       <DragAndDrop onDrop={onDrop} onDragOver={onDragOver}>
-        <div>Drag & Drop your image here</div>
+        {imageData ? (
+          <img src={imageData as string} alt="here" />
+        ) : (
+          <div>Drag & Drop your image here</div>
+        )}
       </DragAndDrop>
-      <Or>Or</Or>
-      <InputLabel>
-        choose a file
-        <input
-          name="image"
-          accept="image/*"
-          type="file"
-          onChange={onChangeInput}
-        />
-      </InputLabel>
+      {imageData ? null : <Or>Or</Or>}
+      {imageData ? (
+        <div>
+          <span></span>
+          <button>Copy Link</button>
+        </div>
+      ) : (
+        <InputLabel>
+          choose a file
+          <input
+            name="image"
+            accept="image/*"
+            type="file"
+            onChange={onChangeInput}
+          />
+        </InputLabel>
+      )}
     </ImageUploaderConteiner>
   );
 };

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -25,7 +25,7 @@ const postImageData: PostImageData = async (files) => {
       },
     });
   } catch (e) {
-    console.error(e);
+    throw new Error();
   }
 };
 

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -102,12 +102,7 @@ const ImageUploader: VFC = () => {
         )}
       </DragAndDropWrapper>
       {imageData ? null : <Or>Or</Or>}
-      {imageData ? (
-        <CopyLink>
-          <span></span>
-          <button>Copy Link</button>
-        </CopyLink>
-      ) : (
+      {imageData ? null : (
         <InputLabel>
           choose a file
           <input
@@ -192,38 +187,6 @@ const InputLabel = styled.label`
 const MaterialIcon = styled.span`
   font-size: 40px;
   color: #219653;
-`;
-
-const CopyLink = styled.div`
-  display: inline-flex;
-  justify-content: space-between;
-  align-items: center;
-  width: 338px;
-  height: 34px;
-  margin-top: 25px;
-  background-color: #f6f8fb;
-  border: 1px solid #e0e0e0;
-  border-radius: 8px;
-
-  > span {
-    color: #4f4f4f;
-    font-size: 8px;
-    width: 240px;
-    height: 12px;
-    margin-left: 7px;
-    text-overflow: ellipsis;
-    overflow: hidden;
-  }
-
-  > button {
-    color: #fff;
-    font-size: 8px;
-    width: 74px;
-    height: 30px;
-    background-color: #2f80ed;
-    border-color: transparent;
-    border-radius: 8px;
-  }
 `;
 
 export default ImageUploader;

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -195,7 +195,7 @@ const MaterialIcon = styled.span`
 `;
 
 const CopyLink = styled.div`
-  display: flex;
+  display: inline-flex;
   justify-content: space-between;
   align-items: center;
   width: 338px;

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -101,10 +101,10 @@ const ImageUploader: VFC = () => {
       </DragAndDrop>
       {imageData ? null : <Or>Or</Or>}
       {imageData ? (
-        <div>
+        <CopyLink>
           <span></span>
           <button>Copy Link</button>
-        </div>
+        </CopyLink>
       ) : (
         <InputLabel>
           choose a file
@@ -187,4 +187,37 @@ const MaterialIcon = styled.span`
   font-size: 40px;
   color: #219653;
 `;
+
+const CopyLink = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 338px;
+  height: 34px;
+  margin-top: 25px;
+  background-color: #f6f8fb;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+
+  > span {
+    color: #4f4f4f;
+    font-size: 8px;
+    width: 240px;
+    height: 12px;
+    margin-left: 7px;
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
+
+  > button {
+    color: #fff;
+    font-size: 8px;
+    width: 74px;
+    height: 30px;
+    background-color: #2f80ed;
+    border-color: transparent;
+    border-radius: 8px;
+  }
+`;
+
 export default ImageUploader;

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -38,7 +38,11 @@ const ImageUploader: VFC = () => {
       return;
     }
 
-    await postImageData(files);
+    try {
+      await postImageData(files);
+    } catch (e) {
+      alert("Upload failed");
+    }
 
     e.target.value = "";
   };
@@ -56,7 +60,11 @@ const ImageUploader: VFC = () => {
       return;
     }
 
-    await postImageData(e.dataTransfer.files);
+    try {
+      await postImageData(e.dataTransfer.files);
+    } catch (e) {
+      alert("Upload failed");
+    }
   };
 
   const onDragOver = (e: MouseEvent) => {

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -92,13 +92,15 @@ const ImageUploader: VFC = () => {
         {imageData ? "Uploaded Successfully!" : "Upload your image"}
       </Header>
       {imageData ? null : <Hint>FIle should be Jpeg Png...</Hint>}
-      {imageData ? (
-        <img src={imageData as string} alt="here" />
-      ) : (
-        <DragAndDrop onDrop={onDrop} onDragOver={onDragOver}>
-          <div>Drag & Drop your image here</div>
-        </DragAndDrop>
-      )}
+      <DragAndDropWrapper>
+        {imageData ? (
+          <img src={imageData as string} alt="here" />
+        ) : (
+          <DragAndDrop onDrop={onDrop} onDragOver={onDragOver}>
+            <div>Drag & Drop your image here</div>
+          </DragAndDrop>
+        )}
+      </DragAndDropWrapper>
       {imageData ? null : <Or>Or</Or>}
       {imageData ? (
         <CopyLink>
@@ -137,6 +139,10 @@ const Hint = styled.div`
   color: #828282;
   font-size: 10px;
   margin-top: 16px;
+`;
+
+const DragAndDropWrapper = styled.div`
+  margin-top: 25px;
 `;
 
 const DragAndDrop = styled.div`


### PR DESCRIPTION
## 目的
devChallenge - Image Uploader 
([https://devchallenges.io/challenges/O2iGT9yBd6xZBrOcVirx](https://devchallenges.io/challenges/O2iGT9yBd6xZBrOcVirx))のユーザーストーリより

- User story: When the image is uploaded, I can see the image and copy it 

の実装のため

## 内容
- 画像プレビューページのHTMLを作成し、画像選択ページと切り替わるようにする
- アップロード完了後に、アップロード画像が表示される

## 確認手順
画像ドロップエリアに画像をドラッグアンドドロップする、もしくは`choose a file`ボタンを押して画像を選択し決定することで、ページが変わります

## 変更結果
アップロードした画像が表示される

## 備考
このPRの目的のユーザーストーリにおけるコピーは、画像を右クリックしてできるコピーとして実装しています

