### PR TITLE
サーバー上のアップロード画像のURLを表示して、クリップボードへコピーする機能の追加

### DIFF
--- a/mock/server.ts
+++ b/mock/server.ts
@@ -3,7 +3,9 @@ import multer from "multer";
 
 const PORT = 4000;
 const server = jsonServer.create();
-const middlewares = jsonServer.defaults({ static: `${__dirname}/public` });
+const middlewares = jsonServer.defaults({
+  static: `${__dirname}/public/image`,
+});
 const storage = multer.diskStorage({
   destination: `${__dirname}/public/image`,
   filename: (req, file, cb) => {

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -33,6 +33,8 @@ const postImageData: PostImageData = async (files) => {
 
 const ImageUploader: VFC = () => {
   const [imageData, setImageData] = useState<string | ArrayBuffer | null>();
+  const [imageUrlOnServer, setImageUrlOnServer] = useState("");
+
   const reader = new FileReader();
   reader.onload = (e) => {
     if (!e.target) {
@@ -49,9 +51,12 @@ const ImageUploader: VFC = () => {
       return;
     }
 
+    const fileName = files[0].name;
+
     try {
       await postImageData(files);
       reader.readAsDataURL(files[0]);
+      setImageUrlOnServer(`${SERVER_URL}/${fileName}`);
     } catch (e) {
       alert("Upload failed");
     }
@@ -72,9 +77,12 @@ const ImageUploader: VFC = () => {
       return;
     }
 
+    const fileName = files[0].name;
+
     try {
       await postImageData(e.dataTransfer.files);
       reader.readAsDataURL(files[0]);
+      setImageUrlOnServer(`${SERVER_URL}/${fileName}`);
     } catch (e) {
       alert("Upload failed");
     }
@@ -105,7 +113,7 @@ const ImageUploader: VFC = () => {
       {imageData ? null : <Or>Or</Or>}
       {imageData ? (
         <CopyLink>
-          <span></span>
+          <span>{imageUrlOnServer}</span>
           <button>Copy Link</button>
         </CopyLink>
       ) : (

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -102,7 +102,12 @@ const ImageUploader: VFC = () => {
         )}
       </DragAndDropWrapper>
       {imageData ? null : <Or>Or</Or>}
-      {imageData ? null : (
+      {imageData ? (
+        <div>
+          <span></span>
+          <button>Copy Link</button>
+        </div>
+      ) : (
         <InputLabel>
           choose a file
           <input

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -92,6 +92,14 @@ const ImageUploader: VFC = () => {
     e.preventDefault();
   };
 
+  const copyUrlToClipboard = () => {
+    try {
+      navigator.clipboard.writeText(imageUrlOnServer);
+    } catch (e) {
+      alert("Copy to clipboard failed!");
+    }
+  };
+
   return (
     <ImageUploaderConteiner>
       {imageData ? (
@@ -114,7 +122,7 @@ const ImageUploader: VFC = () => {
       {imageData ? (
         <CopyLink>
           <span>{imageUrlOnServer}</span>
-          <button>Copy Link</button>
+          <button onClick={copyUrlToClipboard}>Copy Link</button>
         </CopyLink>
       ) : (
         <InputLabel>

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -95,6 +95,7 @@ const ImageUploader: VFC = () => {
   const copyUrlToClipboard = () => {
     try {
       navigator.clipboard.writeText(imageUrlOnServer);
+      alert("Successful copy to clipboard");
     } catch (e) {
       alert("Copy to clipboard failed!");
     }

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -226,7 +226,6 @@ const CopyLink = styled.div`
     color: #4f4f4f;
     font-size: 8px;
     width: 240px;
-    height: 12px;
     margin-left: 7px;
     text-overflow: ellipsis;
     overflow: hidden;

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -103,10 +103,10 @@ const ImageUploader: VFC = () => {
       </DragAndDropWrapper>
       {imageData ? null : <Or>Or</Or>}
       {imageData ? (
-        <div>
+        <CopyLink>
           <span></span>
           <button>Copy Link</button>
-        </div>
+        </CopyLink>
       ) : (
         <InputLabel>
           choose a file
@@ -192,6 +192,38 @@ const InputLabel = styled.label`
 const MaterialIcon = styled.span`
   font-size: 40px;
   color: #219653;
+`;
+
+const CopyLink = styled.div`
+  display: inline-flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 338px;
+  height: 34px;
+  margin-top: 25px;
+  background-color: #f6f8fb;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+
+  > span {
+    color: #4f4f4f;
+    font-size: 8px;
+    width: 240px;
+    height: 12px;
+    margin-left: 7px;
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
+
+  > button {
+    color: #fff;
+    font-size: 8px;
+    width: 74px;
+    height: 30px;
+    background-color: #2f80ed;
+    border-color: transparent;
+    border-radius: 8px;
+  }
 `;
 
 export default ImageUploader;

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -8,7 +8,8 @@ type OnChangeInput = (e: ChangeEvent<HTMLInputElement>) => Promise<void>;
 type PostImageData = (files: FileList | null) => Promise<void>;
 type OnDrop = (e: DragEvent) => Promise<void>;
 
-const URL = "http://localhost:4000/public/image";
+const SERVER_URL = "http://localhost:4000";
+const POST_IMAGE_URL = `${SERVER_URL}/public/image`;
 
 const postImageData: PostImageData = async (files) => {
   const postImage = new FormData();
@@ -20,7 +21,7 @@ const postImageData: PostImageData = async (files) => {
   postImage.append("image", files[0]);
 
   try {
-    await axios.post(URL, postImage, {
+    await axios.post(POST_IMAGE_URL, postImage, {
       headers: {
         "Content-Type": "multipart/form-data",
       },

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -121,7 +121,7 @@ const ImageUploader: VFC = () => {
       {imageData ? null : <Or>Or</Or>}
       {imageData ? (
         <CopyLink>
-          <span>{imageUrlOnServer}</span>
+          <div>{imageUrlOnServer}</div>
           <button onClick={copyUrlToClipboard}>Copy Link</button>
         </CopyLink>
       ) : (
@@ -222,7 +222,7 @@ const CopyLink = styled.div`
   border: 1px solid #e0e0e0;
   border-radius: 8px;
 
-  > span {
+  > div {
     color: #4f4f4f;
     font-size: 8px;
     width: 240px;
@@ -230,6 +230,7 @@ const CopyLink = styled.div`
     margin-left: 7px;
     text-overflow: ellipsis;
     overflow: hidden;
+    white-space: nowrap;
   }
 
   > button {


### PR DESCRIPTION
## 目的
devChallenge - Image Uploader 
([https://devchallenges.io/challenges/O2iGT9yBd6xZBrOcVirx](https://devchallenges.io/challenges/O2iGT9yBd6xZBrOcVirx))のユーザーストーリより
- User story: I can choose to copy to the clipboard

の実装のため

## 内容
アップロード画像の保存先のURLの表示と、それをクリップボードへコピーするボタンの追加

## 確認手順
```sh
npm start
```
と
```sh
npm run server
```
を起動して、画像をアップロードしページ切り替え後に、ページ下部の`Copy Link`ボタンを押すとリンクがクリップボードへコピーされるので、それをブラウザのURL入力欄に入力すると画像が表示される

## 変更結果
### アップロード後の画像
![image-uploader-結果](https://user-images.githubusercontent.com/66302618/141984375-60b7b8db-7628-4d17-b418-bbace4274609.PNG)
### クリップボードへのコピーした時の画像
![image-uploader-結果2](https://user-images.githubusercontent.com/66302618/141984533-9711c866-5546-4b8a-8ba3-5611328ea4ab.PNG)
