### PR TITLE
画像をアップロード中に表示するアニメーションを追加

### DIFF
--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -109,7 +109,10 @@ const ImageUploader: VFC = () => {
   };
 
   return isUploading ? (
-    <LoadingContainer>Uploading...</LoadingContainer>
+    <LoadingContainer>
+      Uploading...
+      <LoadingAnimation></LoadingAnimation>
+    </LoadingContainer>
   ) : (
     <ImageUploaderConteiner>
       {imageData ? (
@@ -263,6 +266,35 @@ const LoadingContainer = styled.div`
   background-color: #fff;
   box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.1);
   border-radius: 12px;
+`;
+
+const LoadingAnimation = styled.div`
+  position: relative;
+  width: 340px;
+  height: 6px;
+  margin-top: 31px;
+  background-color: #f2f2f2;
+  border-radius: 8px;
+  overflow: hidden;
+
+  &::before {
+    content: "";
+    position: absolute;
+    background-color: #2f80ed;
+    border-radius: 8px;
+    width: 101px;
+    height: 6px;
+    animation: lineAnime 1.5s linear 0s infinite normal forwards;
+  }
+
+  @keyframes lineAnime {
+    from {
+      transform: translateX(-100px);
+    }
+    to {
+      transform: translateX(340px);
+    }
+  }
 `;
 
 export default ImageUploader;

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -109,7 +109,7 @@ const ImageUploader: VFC = () => {
   };
 
   return isUploading ? (
-    <div>Uploading...</div>
+    <LoadingContainer>Uploading...</LoadingContainer>
   ) : (
     <ImageUploaderConteiner>
       {imageData ? (
@@ -251,6 +251,18 @@ const CopyLink = styled.div`
     border-color: transparent;
     border-radius: 8px;
   }
+`;
+
+const LoadingContainer = styled.div`
+  color: #4f4f4f;
+  font-size: 18px;
+  width: 400px;
+  height: 144px;
+  padding-top: 36px;
+  padding-left: 32px;
+  background-color: #fff;
+  box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.1);
+  border-radius: 12px;
 `;
 
 export default ImageUploader;

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -34,6 +34,7 @@ const postImageData: PostImageData = async (files) => {
 const ImageUploader: VFC = () => {
   const [imageData, setImageData] = useState<string | ArrayBuffer | null>();
   const [imageUrlOnServer, setImageUrlOnServer] = useState("");
+  const [isUploading, setIsUploading] = useState(false);
 
   const reader = new FileReader();
   reader.onload = (e) => {
@@ -54,11 +55,14 @@ const ImageUploader: VFC = () => {
     const fileName = files[0].name;
 
     try {
+      setIsUploading(true);
       await postImageData(files);
       reader.readAsDataURL(files[0]);
       setImageUrlOnServer(`${SERVER_URL}/${fileName}`);
+      setIsUploading(false);
     } catch (e) {
       alert("Upload failed");
+      setIsUploading(false);
     }
 
     e.target.value = "";
@@ -80,11 +84,14 @@ const ImageUploader: VFC = () => {
     const fileName = files[0].name;
 
     try {
+      setIsUploading(true);
       await postImageData(e.dataTransfer.files);
       reader.readAsDataURL(files[0]);
       setImageUrlOnServer(`${SERVER_URL}/${fileName}`);
+      setIsUploading(false);
     } catch (e) {
       alert("Upload failed");
+      setIsUploading(false);
     }
   };
 
@@ -101,7 +108,9 @@ const ImageUploader: VFC = () => {
     }
   };
 
-  return (
+  return isUploading ? (
+    <div>Uploading...</div>
+  ) : (
     <ImageUploaderConteiner>
       {imageData ? (
         <MaterialIcon className="material-icons">check_circle</MaterialIcon>


### PR DESCRIPTION
## 目的
devChallenge - Image Uploader 
([https://devchallenges.io/challenges/O2iGT9yBd6xZBrOcVirx](https://devchallenges.io/challenges/O2iGT9yBd6xZBrOcVirx))のユーザーストーリより
- User story: I can see a loader when uploading

の実装

## 内容
画像をアップロード中にアップローディング画面に切り替わりアニメーションが表示される

## 確認手順
```js
await new Promise((r) => setTimeout(r, 1500));
```
を`onChangeInput`関数または`onDrop`関数の`try`ブロックの1行目の
```js
setIsUploading(true);
```
の下に追加し、画像をアップロードする

## 変更結果
### 以下が表示される
![uploading](https://user-images.githubusercontent.com/66302618/142003021-f28c5854-0889-426e-97cd-eb56f4e21e79.PNG)
